### PR TITLE
Update helm docs: remove manual image.tag requirement

### DIFF
--- a/content/_include/helm-controlplane.md
+++ b/content/_include/helm-controlplane.md
@@ -14,14 +14,19 @@ curl -o values-example.yaml https://raw.githubusercontent.com/helixml/helix/main
 
 You **must** edit the provider configuration in this file so that Helix can run. Specifying a remote provider (e.g. `openai` or `togetherai`) is the easiest, but you must provide API keys to do that. A `helix` provider ensures local operation but then you must also add a runner.
 
-Now you're ready to install the control plane helm chart with the latest images.
+Now you're ready to install the control plane helm chart.
 
 ```bash
-export LATEST_RELEASE=$(curl -s https://get.helixml.tech/latest.txt)
-
 helm upgrade --install my-helix-controlplane helix/helix-controlplane \
-  -f values-example.yaml \
-  --set image.tag="${LATEST_RELEASE}"
+  -f values-example.yaml
+```
+
+The chart automatically uses the correct image version via its `appVersion`. To pin a specific version:
+
+```bash
+helm upgrade --install my-helix-controlplane helix/helix-controlplane \
+  --version 2.7.12 \
+  -f values-example.yaml
 ```
 
 Ensure all the pods start. If they do not inspect the logs.

--- a/content/helix/private-deployment/manual-install/kubernetes.md
+++ b/content/helix/private-deployment/manual-install/kubernetes.md
@@ -47,13 +47,11 @@ This section describes how to install a Helix runner on Kubernetes.
 Then, install the runner:
 
 ```bash
-export LATEST_RELEASE=$(curl -s https://get.helixml.tech/latest.txt)
 helm upgrade --install my-helix-runner helix/helix-runner \
   --set runner.host="my-helix-controlplane" \
   --set runner.token="oh-hallo-insecure-token" \
   --set runner.memory=24GB \
-  --set replicaCount=1 \
-  --set image.tag="${LATEST_RELEASE}-small"
+  --set replicaCount=1
 ```
 
 ## More Help


### PR DESCRIPTION
## Summary
- Helm charts now auto-select the correct image tag via `appVersion` — no need for `--set image.tag`
- Chart versions are aligned with app versions on release (e.g. chart 2.7.12 = images 2.7.12)
- Removed `export LATEST_RELEASE` / `--set image.tag` from controlplane and runner install commands
- Added example for pinning a specific chart version

## Context
PR helixml/helix#1806 and helixml/helix#1810 fixed helm chart defaults and added CI auto-stamping. This updates the docs to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)